### PR TITLE
Make Document/Entity default table names plural

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ var account = CloudStorageAccount.DevelopmentStorageAccount; // or production on
 // We lay out the parameter names for clarity only.
 // also be provided to the factory method to override the default behavior.
 var repo = TablePartition.Create<Region>(storageAccount, 
-  // tableName defaults to "Entity" if not provided
+  // tableName defaults to "Entities" if not provided
   tableName: "Reference",
   // partitionKey would default to "Region" too if not provided
   partitionKey: "Region",

--- a/src/TableStorage/DocumentPartition.cs
+++ b/src/TableStorage/DocumentPartition.cs
@@ -20,7 +20,7 @@ namespace Devlooped
         /// Default table name to use when a value is not not provided 
         /// (or overriden via <see cref="TableAttribute"/>), which is <c>Document</c>.
         /// </summary>
-        public const string DefaultTableName = "Document";
+        public const string DefaultTableName = "Documents";
 
         /// <summary>
         /// Creates an <see cref="ITablePartition{T}"/> for the given entity type 

--- a/src/TableStorage/TablePartition.cs
+++ b/src/TableStorage/TablePartition.cs
@@ -20,7 +20,7 @@ namespace Devlooped
         /// Default table name to use when a value is not not provided 
         /// (or overriden via <see cref="TableAttribute"/>), which is <c>Entity</c>.
         /// </summary>
-        public const string DefaultTableName = "Entity";
+        public const string DefaultTableName = "Entities";
 
         /// <summary>
         /// Creates an <see cref="ITablePartition{TableEntity}"/>, using 


### PR DESCRIPTION
These default table names are used when creating partitions within a single table, which will therefore store documents/entities of different types.

If they all were of the same type, it might make sense to make the word singular, but since they will effectively contain a mix of entity/document types, it's more appropriate to make it plural.

Fixes #28