### PR TITLE
Add support for record constructor parameter annotations

### DIFF
--- a/src/TableStorage/PartitionKeyAttribute.cs
+++ b/src/TableStorage/PartitionKeyAttribute.cs
@@ -11,7 +11,7 @@ namespace Devlooped
     /// Can be applied at the class level instead with a fixed value to persist 
     /// entities with a fixed partition key value.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Parameter)]
     partial class PartitionKeyAttribute : TableStorageAttribute
     {
         /// <summary>

--- a/src/TableStorage/RowKeyAttribute.cs
+++ b/src/TableStorage/RowKeyAttribute.cs
@@ -7,9 +7,10 @@ namespace Devlooped
 {
     /// <summary>
     /// Flags the property to use as the table storage row key 
-    /// when storing the annotated type using the <see cref="TableRepository{T}"/>.
+    /// when storing the annotated type using <see cref="TableRepository{T}"/> or 
+    /// <see cref="TablePartition{T}"/>.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
     partial class RowKeyAttribute : TableStorageAttribute
     {
         /// <summary>

--- a/src/TableStorage/TableStorageAttribute.cs
+++ b/src/TableStorage/TableStorageAttribute.cs
@@ -33,10 +33,23 @@ namespace Devlooped
             var keyProp = typeof(TEntity).GetProperties()
                 .FirstOrDefault(prop => prop.GetCustomAttribute<TAttribute>() != null);
 
+            // See if the attribute is applied to a constructor argument with the same name 
+            // as a prop, like it would in a record type
+            if (keyProp == null)
+            {
+                var keyParam = typeof(TEntity).GetConstructors().SelectMany(ctor => ctor.GetParameters())
+                    .Where(prm => prm.GetCustomAttribute<TAttribute>() != null)
+                    .FirstOrDefault();
+
+                if (keyParam != null)
+                    keyProp = typeof(TEntity).GetProperties().FirstOrDefault(prop => prop.Name == keyParam.Name);
+            }
+
             if (keyProp == null)
             {
                 if (typeof(TAttribute) == typeof(PartitionKeyAttribute))
                 {
+                    // See if the attribute is applied at the class level with a fixed value
                     var partitionKey = typeof(TEntity).GetCustomAttribute<PartitionKeyAttribute>()?.PartitionKey;
                     if (partitionKey == null)
                     {


### PR DESCRIPTION
When using C# 9 records for storage (super convenient!), you typically don't declare the properties explicitly, but leverage the concise syntax instead, so now you can do:

```
public record Book([RowKey] string ISBN, [PartitionKey] string Author, string Title);
```

Fixes #43