### PR TITLE
Allow additional properties in table entity repository

### DIFF
--- a/src/TableStorage/TableEntityPartition.cs
+++ b/src/TableStorage/TableEntityPartition.cs
@@ -10,7 +10,7 @@ using Microsoft.Azure.Cosmos.Table;
 namespace Devlooped
 {
     /// <inheritdoc />
-    partial class TableEntityPartition : ITablePartition<TableEntity>
+    partial class TableEntityPartition : ITablePartition<ITableEntity>
     {
         readonly TableEntityRepository repository;
 
@@ -33,16 +33,25 @@ namespace Devlooped
         /// <inheritdoc />
         public string PartitionKey { get; }
 
-        /// <inheritdoc />
-        public IQueryable<TableEntity> CreateQuery() => repository.CreateQuery().Where(x => x.PartitionKey == PartitionKey);
+        /// <summary>
+        /// The strategy to use when updating an existing entity.
+        /// </summary>
+        public UpdateStrategy UpdateStrategy
+        {
+            get => repository.UpdateStrategy;
+            set => repository.UpdateStrategy = value;
+        }
 
         /// <inheritdoc />
-        public async Task DeleteAsync(TableEntity entity, CancellationToken cancellation = default)
+        public IQueryable<ITableEntity> CreateQuery() => repository.CreateQuery().Where(x => x.PartitionKey == PartitionKey);
+
+        /// <inheritdoc />
+        public Task DeleteAsync(ITableEntity entity, CancellationToken cancellation = default)
         {
             if (!PartitionKey.Equals(entity.PartitionKey, StringComparison.Ordinal))
                 throw new ArgumentException("Entity does not belong to the partition.");
 
-            await repository.DeleteAsync(entity, cancellation);
+            return repository.DeleteAsync(entity, cancellation);
         }
 
         /// <inheritdoc />
@@ -50,20 +59,20 @@ namespace Devlooped
             => repository.DeleteAsync(PartitionKey, rowKey, cancellation);
 
         /// <inheritdoc />
-        public IAsyncEnumerable<TableEntity> EnumerateAsync(CancellationToken cancellation = default) 
+        public IAsyncEnumerable<ITableEntity> EnumerateAsync(CancellationToken cancellation = default) 
             => repository.EnumerateAsync(PartitionKey, cancellation);
 
         /// <inheritdoc />
-        public Task<TableEntity?> GetAsync(string rowKey, CancellationToken cancellation = default)
+        public Task<ITableEntity?> GetAsync(string rowKey, CancellationToken cancellation = default)
             => repository.GetAsync(PartitionKey, rowKey, cancellation);
 
         /// <inheritdoc />
-        public async Task<TableEntity> PutAsync(TableEntity entity, CancellationToken cancellation = default)
+        public Task<ITableEntity> PutAsync(ITableEntity entity, CancellationToken cancellation = default)
         {
             if (!PartitionKey.Equals(entity.PartitionKey, StringComparison.Ordinal))
                 throw new ArgumentException("Entity does not belong to the partition.");
 
-            return await repository.PutAsync(entity, cancellation);
+            return repository.PutAsync(entity, cancellation);
         }
     }
 }

--- a/src/TableStorage/TablePartition.cs
+++ b/src/TableStorage/TablePartition.cs
@@ -23,14 +23,15 @@ namespace Devlooped
         public const string DefaultTableName = "Entities";
 
         /// <summary>
-        /// Creates an <see cref="ITablePartition{TableEntity}"/>, using 
+        /// Creates an <see cref="ITablePartition{ITableEntity}"/>, using 
         /// <see cref="DefaultTableName"/> as the table name and the 
         /// <typeparamref name="T"/> <c>Name</c> as the partition key.
         /// </summary>
         /// <param name="storageAccount">The storage account to use.</param>
+        /// <param name="updateStrategy">Strategy to apply when updating an existing entity. Defaults to <see cref="UpdateStrategy.Replace"/>.</param>
         /// <returns>The new <see cref="ITablePartition{TEntity}"/>.</returns>
-        public static ITablePartition<TableEntity> Create(CloudStorageAccount storageAccount, string tableName, string partitionKey)
-            => new TableEntityPartition(storageAccount, tableName, partitionKey);
+        public static ITablePartition<ITableEntity> Create(CloudStorageAccount storageAccount, string tableName, string partitionKey, UpdateStrategy? updateStrategy = default)
+            => new TableEntityPartition(storageAccount, tableName, partitionKey) { UpdateStrategy = updateStrategy ?? UpdateStrategy.Replace };
 
         /// <summary>
         /// Creates an <see cref="ITablePartition{T}"/> for the given entity type 

--- a/src/TableStorage/TableRepository.cs
+++ b/src/TableStorage/TableRepository.cs
@@ -17,15 +17,17 @@ namespace Devlooped
         static readonly ConcurrentDictionary<Type, string> defaultTableNames = new();
 
         /// <summary>
-        /// Creates an <see cref="ITableRepository{TableEntity}"/> repository.
+        /// Creates an <see cref="ITableRepository{ITableEntity}"/> repository.
         /// </summary>
         /// <param name="storageAccount">The storage account to use.</param>
         /// <param name="tableName">Table name to use.</param>
-        /// <returns>The new <see cref="ITableRepository{TableEntity}"/>.</returns>
-        public static ITableRepository<TableEntity> Create(
+        /// <param name="updateStrategy">Strategy to apply when updating an existing entity. Defaults to <see cref="UpdateStrategy.Replace"/>.</param>
+        /// <returns>The new <see cref="ITableRepository{ITableEntity}"/>.</returns>
+        public static ITableRepository<ITableEntity> Create(
             CloudStorageAccount storageAccount,
-            string tableName)
-            => new TableEntityRepository(storageAccount, tableName);
+            string tableName,
+            UpdateStrategy? updateStrategy = default)
+            => new TableEntityRepository(storageAccount, tableName) { UpdateStrategy = updateStrategy ?? UpdateStrategy.Replace };
 
         /// <summary>
         /// Creates an <see cref="ITableRepository{T}"/> for the given entity type 


### PR DESCRIPTION
By switching the public API to ITableEntity, we remain API-compatible with the previous version, but using DynamicTableEntity implementation internally allows saving/merging additional properties as needed.

The caller would need to downcast to `DynamicTableEntity` still, but the scenario woiuld be enabled.

Fixes #48