### PR TITLE
When deleting entities, return boolean status for success/failure

### DIFF
--- a/src/TableStorage/DocumentPartition`1.cs
+++ b/src/TableStorage/DocumentPartition`1.cs
@@ -40,11 +40,11 @@ namespace Devlooped
         public string PartitionKey { get; }
 
         /// <inheritdoc />
-        public Task DeleteAsync(T entity, CancellationToken cancellation = default)
+        public Task<bool> DeleteAsync(T entity, CancellationToken cancellation = default)
             => repository.DeleteAsync(entity, cancellation);
 
         /// <inheritdoc />
-        public Task DeleteAsync(string rowKey, CancellationToken cancellation = default)
+        public Task<bool> DeleteAsync(string rowKey, CancellationToken cancellation = default)
             => repository.DeleteAsync(PartitionKey, rowKey, cancellation);
         
         /// <inheritdoc />

--- a/src/TableStorage/ITableStoragePartition`1.cs
+++ b/src/TableStorage/ITableStoragePartition`1.cs
@@ -49,13 +49,13 @@ namespace Devlooped
         /// </summary>
         /// <param name="entity">The entity to delete.</param>
         /// <param name="cancellation">Optional <see cref="CancellationToken"/>.</param>
-        Task DeleteAsync(T entity, CancellationToken cancellation = default);
+        Task<bool> DeleteAsync(T entity, CancellationToken cancellation = default);
 
         /// <summary>
         /// Deletes an entity from the partition given its <paramref name="rowKey"/>.
         /// </summary>
         /// <param name="rowKey">The entity row key.</param>
         /// <param name="cancellation">Optional <see cref="CancellationToken"/>.</param>
-        Task DeleteAsync(string rowKey, CancellationToken cancellation = default);
+        Task<bool> DeleteAsync(string rowKey, CancellationToken cancellation = default);
     }
 }

--- a/src/TableStorage/ITableStorage`1.cs
+++ b/src/TableStorage/ITableStorage`1.cs
@@ -22,7 +22,8 @@ namespace Devlooped
         /// </summary>
         /// <param name="entity">The entity to delete.</param>
         /// <param name="cancellation">Optional <see cref="CancellationToken"/>.</param>
-        Task DeleteAsync(T entity, CancellationToken cancellation = default);
+        /// <returns><see langword="true"/> if an existing record was deleted, <see langword="true"/> otherwise.</returns>
+        Task<bool> DeleteAsync(T entity, CancellationToken cancellation = default);
 
         /// <summary>
         /// Deletes an entity from the repository given its <paramref name="partitionKey"/> and <paramref name="rowKey"/>.
@@ -30,7 +31,8 @@ namespace Devlooped
         /// <param name="partitionKey">The entity partition key.</param>
         /// <param name="rowKey">The entity row key.</param>
         /// <param name="cancellation">Optional <see cref="CancellationToken"/>.</param>
-        Task DeleteAsync(string partitionKey, string rowKey, CancellationToken cancellation = default);
+        /// <returns><see langword="true"/> if an existing record was deleted, <see langword="true"/> otherwise.</returns>
+        Task<bool> DeleteAsync(string partitionKey, string rowKey, CancellationToken cancellation = default);
 
         /// <summary>
         /// Enumerates asynchronously all entities, optionally within the given <paramref name="partitionKey"/>.

--- a/src/TableStorage/TableEntityPartition.cs
+++ b/src/TableStorage/TableEntityPartition.cs
@@ -46,7 +46,7 @@ namespace Devlooped
         public IQueryable<ITableEntity> CreateQuery() => repository.CreateQuery().Where(x => x.PartitionKey == PartitionKey);
 
         /// <inheritdoc />
-        public Task DeleteAsync(ITableEntity entity, CancellationToken cancellation = default)
+        public Task<bool> DeleteAsync(ITableEntity entity, CancellationToken cancellation = default)
         {
             if (!PartitionKey.Equals(entity.PartitionKey, StringComparison.Ordinal))
                 throw new ArgumentException("Entity does not belong to the partition.");
@@ -55,7 +55,7 @@ namespace Devlooped
         }
 
         /// <inheritdoc />
-        public Task DeleteAsync(string rowKey, CancellationToken cancellation = default)
+        public Task<bool> DeleteAsync(string rowKey, CancellationToken cancellation = default)
             => repository.DeleteAsync(PartitionKey, rowKey, cancellation);
 
         /// <inheritdoc />

--- a/src/TableStorage/TablePartition`1.cs
+++ b/src/TableStorage/TablePartition`1.cs
@@ -58,11 +58,11 @@ namespace Devlooped
         }
 
         /// <inheritdoc />
-        public Task DeleteAsync(T entity, CancellationToken cancellation = default)
+        public Task<bool> DeleteAsync(T entity, CancellationToken cancellation = default)
             => repository.DeleteAsync(entity, cancellation);
 
         /// <inheritdoc />
-        public Task DeleteAsync(string rowKey, CancellationToken cancellation = default)
+        public Task<bool> DeleteAsync(string rowKey, CancellationToken cancellation = default)
             => repository.DeleteAsync(PartitionKey, rowKey, cancellation);
         
         /// <inheritdoc />

--- a/src/Tests/RepositoryTests.cs
+++ b/src/Tests/RepositoryTests.cs
@@ -33,7 +33,7 @@ namespace Devlooped
 
             Assert.Single(entities);
 
-            await repo.DeleteAsync(saved);
+            Assert.True(await repo.DeleteAsync(saved));
 
             Assert.Null(await repo.GetAsync("My", "asdf"));
 
@@ -66,7 +66,7 @@ namespace Devlooped
 
             Assert.Single(entities);
 
-            await repo.DeleteAsync(saved);
+            Assert.True(await repo.DeleteAsync(saved));
 
             Assert.Null(await repo.GetAsync("Book", "1234"));
 
@@ -129,7 +129,7 @@ namespace Devlooped
 
             Assert.Single(entities);
 
-            await repo.DeleteAsync(saved);
+            Assert.True(await repo.DeleteAsync(saved));
 
             Assert.Null(await repo.GetAsync("asdf"));
 
@@ -185,7 +185,7 @@ namespace Devlooped
 
             Assert.Single(entities);
 
-            await repo.DeleteAsync(saved);
+            Assert.True(await repo.DeleteAsync(saved));
 
             Assert.Null(await repo.GetAsync("123", "Foo"));
 
@@ -219,7 +219,7 @@ namespace Devlooped
 
             Assert.Single(entities);
 
-            await partition.DeleteAsync(saved);
+            Assert.True(await partition.DeleteAsync(saved));
 
             Assert.Null(await partition.GetAsync("123"));
 
@@ -253,6 +253,31 @@ namespace Devlooped
                 Assert.Equal("Watched", entity.PartitionKey);
                 Assert.NotNull(entity.RowKey);
             }
+        }
+
+        [Fact]
+        public async Task CanDeleteNonExistentEntity()
+        {
+            await CloudStorageAccount.DevelopmentStorageAccount.CreateCloudTableClient().GetTableReference(nameof(CanEnumerateEntities))
+                .DeleteIfExistsAsync();
+
+            Assert.False(await TableRepository.Create<MyEntity>(CloudStorageAccount.DevelopmentStorageAccount, nameof(CanEnumerateEntities))
+                .DeleteAsync("foo", "bar"));
+
+            Assert.False(await TablePartition.Create<MyEntity>(CloudStorageAccount.DevelopmentStorageAccount, nameof(CanEnumerateEntities), "Watched")
+                .DeleteAsync("foo"));
+
+            Assert.False(await DocumentRepository.Create<MyEntity>(CloudStorageAccount.DevelopmentStorageAccount, nameof(CanEnumerateEntities))
+                .DeleteAsync("foo", "bar"));
+
+            Assert.False(await DocumentPartition.Create<MyEntity>(CloudStorageAccount.DevelopmentStorageAccount, nameof(CanEnumerateEntities), "Watched")
+                .DeleteAsync("foo"));
+
+            Assert.False(await TableRepository.Create(CloudStorageAccount.DevelopmentStorageAccount, nameof(CanEnumerateEntities))
+                .DeleteAsync("foo", "bar"));
+
+            Assert.False(await TablePartition.Create(CloudStorageAccount.DevelopmentStorageAccount, nameof(CanEnumerateEntities), "Watched")
+                .DeleteAsync("foo"));
         }
 
         [Fact]


### PR DESCRIPTION
Currently, attempting to delete a non-existent entity results in a StorageException. Catch that and instead return a boolean when the operation was successful (based on the returned status code from the operation).

Fixes #50