### PR TITLE
Support Timestamp property in POCO entities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,9 @@ var repo = TableRepository.Create<Product>(...,
 > NOTE: when using alternative serializers, entities might need to be annotated with whatever 
 > attributes are required by the underlying libraries.
 
+> NOTE: if access to the `Timestamp` managed by Table Storage for the entity is needed, just declare a property 
+> with that name with either `DateTimeOffset`, `DateTime` or `string` type.
+
 ### Attributes
 
 If you want to avoid using strings with the factory methods, you can also annotate the 

--- a/src/TableStorage/TableRepository`1.cs
+++ b/src/TableStorage/TableRepository`1.cs
@@ -192,6 +192,8 @@ namespace Devlooped
             if (rowKeyProperty != null)
                 writer.WriteString(rowKeyProperty, entity.RowKey);
 
+            writer.WriteString(nameof(ITableEntity.Timestamp), entity.Timestamp);
+
             foreach (var property in entity.Properties)
             {
                 switch (property.Value.PropertyType)

--- a/src/Tests/RepositoryTests.cs
+++ b/src/Tests/RepositoryTests.cs
@@ -160,6 +160,35 @@ namespace Devlooped
         }
 
         [Fact]
+        public async Task CanReadTimestamp()
+        {
+            await TablePartition
+                .Create<TimestampedEntity>(
+                    CloudStorageAccount.DevelopmentStorageAccount,
+                    "Timestamped", "Timestamped", e => e.ID)
+                .PutAsync(
+                    new TimestampedEntity("Foo"));
+
+            Assert.NotNull((await TablePartition
+                .Create<TimestampedEntity>(
+                    CloudStorageAccount.DevelopmentStorageAccount,
+                    "Timestamped", "Timestamped", e => e.ID)
+                .GetAsync("Foo"))!.Timestamp);
+
+            Assert.NotNull((await TablePartition
+                .Create<StringTimestampedEntity>(
+                    CloudStorageAccount.DevelopmentStorageAccount,
+                    "Timestamped", "Timestamped", e => e.ID)
+                .GetAsync("Foo"))!.Timestamp);
+
+            Assert.NotNull((await TablePartition
+                .Create<TimestampedDateTimeEntity>(
+                    CloudStorageAccount.DevelopmentStorageAccount,
+                    "Timestamped", "Timestamped", e => e.ID)
+                .GetAsync("Foo"))!.Timestamp);
+        }
+
+        [Fact]
         public void DefaultTableNameUsesAttribute()
         {
             Assert.Equal("Entities", TableRepository.Create<MyTableEntity>(CloudStorageAccount.DevelopmentStorageAccount).TableName);
@@ -384,6 +413,21 @@ namespace Devlooped
         {
             public string? Status { get; set; }
             public string? Reason { get; set; }
+        }
+
+        record TimestampedEntity(string ID)
+        {
+            public DateTimeOffset? Timestamp { get; set; }
+        }
+
+        record StringTimestampedEntity(string ID)
+        {
+            public string? Timestamp { get; set; }
+        }
+
+        record TimestampedDateTimeEntity(string ID)
+        {
+            public DateTime? Timestamp { get; set; }
         }
     }
 }


### PR DESCRIPTION
It's sometimes useful to be able to read the Timestamp value managed by Table Storage, so we just allow POCOs to be able to read it by just declaring a property with that name.

Fixes #60