### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/.github_changelog_generator
+++ b/.github/.github_changelog_generator
@@ -1,5 +1,4 @@
 usernames-as-github-logins=true
-header-label=
 issues_wo_labels=true
 pr_wo_labels=true
 exclude-labels=bydesign,dependencies,duplicate,question,invalid,wontfix,need info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,13 +54,41 @@ jobs:
       - name: 🙏 build
         run: dotnet build -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
 
-      - name: ⚙ azurite
+      - name: ⚙ GNU grep
+        if: matrix.os == 'macOS-latest'
         run: |
-          npm install azurite
-          npx azurite-table &
+          brew install grep
+          echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
 
       - name: 🧪 test
-        run: dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m
+        shell: bash --noprofile --norc {0}
+        env:
+          LC_ALL: en_US.utf8
+        run: |
+          [ -f .bash_profile ] && source .bash_profile
+          counter=0
+          exitcode=0
+          reset="\e[0m"
+          warn="\e[0;33m"
+          while [ $counter -lt 6 ]
+          do
+              if [ $filter ]
+              then
+                  echo -e "${warn}Retry $counter for $filter ${reset}"
+              fi
+              # run test and forward output also to a file in addition to stdout (tee command)
+              dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
+              # capture dotnet test exit status, different from tee
+              exitcode=${PIPESTATUS[0]}
+              if [ $exitcode == 0 ]
+              then
+                  exit 0
+              fi
+              # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
+              filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+              ((counter++))
+          done
+          exit $exitcode
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,9 +25,9 @@ jobs:
           token: ${{ env.GH_TOKEN }}
 
       - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
-        with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md
+        run: |
+          sudo gem install github_changelog_generator 
+          github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🚀 changelog
         run: |

--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -53,7 +53,7 @@ jobs:
           branch: dotnet-file-sync
           delete-branch: true
           labels: dependencies
-          commit-message: Bump files with dotnet-file sync
+          commit-message: ⬆️ Bump files with dotnet-file sync
           
             ${{ env.CHANGES }}
           title: "Bump files with dotnet-file sync"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,41 @@ jobs:
       - name: 🙏 build
         run: dotnet build -m:1 -p:version=${GITHUB_REF#refs/*/v}
 
-      - name: ⚙ azurite
+      - name: ⚙ GNU grep
+        if: matrix.os == 'macOS-latest'
         run: |
-          npm install azurite
-          npx azurite-table &
+          brew install grep
+          echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
 
       - name: 🧪 test
-        run: dotnet test --no-build -m:1
+        shell: bash --noprofile --norc {0}
+        env:
+          LC_ALL: en_US.utf8
+        run: |
+          [ -f .bash_profile ] && source .bash_profile
+          counter=0
+          exitcode=0
+          reset="\e[0m"
+          warn="\e[0;33m"
+          while [ $counter -lt 6 ]
+          do
+              if [ $filter ]
+              then
+                  echo -e "${warn}Retry $counter for $filter ${reset}"
+              fi
+              # run test and forward output also to a file in addition to stdout (tee command)
+              dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
+              # capture dotnet test exit status, different from tee
+              exitcode=${PIPESTATUS[0]}
+              if [ $exitcode == 0 ]
+              then
+                  exit 0
+              fi
+              # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
+              filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+              ((counter++))
+          done
+          exit $exitcode
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:version=${GITHUB_REF#refs/*/v}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -21,16 +21,16 @@ jobs:
         run: echo "SINCE_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
 
       - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
         if: env.SINCE_TAG != ''
-        with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --since-tag ${{ env.SINCE_TAG }} --o changelog.md
+        run: |
+          sudo gem install github_changelog_generator 
+          github_changelog_generator --since-tag ${{ env.SINCE_TAG }} --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: ⚙ changelog
-        uses: faberNovel/github-changelog-generator-action@master
         if: env.SINCE_TAG == ''
-        with:
-          options: --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md
+        run: |
+          sudo gem install github_changelog_generator 
+          github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🖉 release
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 obj
 artifacts
 pack
+TestResults
 .vs
 .vscode
 
@@ -27,4 +28,3 @@ _site
 .jekyll-cache
 Gemfile.lock
 package-lock.json
-__azurite_db_table__.json

--- a/.netconfig
+++ b/.netconfig
@@ -49,38 +49,33 @@
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = fc5889d5387e2d5aa7aba279b2aa12251cf08cb2
-	etag = 91e9a208cd134bd7b71d7419800c613bc50a30e21e605607528721f2acdeab86
+	sha = 964caa363fe9cd8ef01c8a5d8e3fd07d1aed35ae
+	etag = ef5ed75b1e23292dd7af196a11f04760aa5ad4a3f374095395da9abc2de3f24f
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
-	sha = 084aa7c36ee1c262ea2f9e83931068366a7b4312
-	etag = 1e17c477f9e26f83367870a18e3727a71dcbb49cd31d85e0cfcfe092202d3a66
+	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
+	etag = 99c02f817f1a2b6ffaec4f7c4cd1c60e6bfae966174568f8027a4a2f42a00e69
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = 084aa7c36ee1c262ea2f9e83931068366a7b4312
-	etag = 501f8bf58287fdd7467701342f7251a015bc29664b494e7d81a71c0c55bee61f
+	sha = 2a39a426f66402e47c80818f92748a1bfd7d736c
+	etag = c424e4f9159bd5d4ccb3b65646a65eed5ad153f57111e3b56900ebce10194f3f
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	sha = 55c0b32601e94e1eed35028a0cad510c6bcbb265
-	etag = ad8681ee3f191f796944135772b74565c470e349464e793aa664c888f7784b7a
+	sha = 964caa363fe9cd8ef01c8a5d8e3fd07d1aed35ae
+	etag = d6369e92c55eb78322ff39d26fc4ef1996b691a8ce05392395ab393e14ddb940
 	weak
 [file ".github/workflows/release-notes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/release-notes.yml
-	sha = b07aaab94cccdaa7cd42eb17c0390ffacb6fbee8
-	etag = b01d73895c1f62e16cfd2a78e36bbf82c4d1332ed747c50002695997b92caf58
-	weak
-[file ".github_changelog_generator"]
-	url = https://github.com/devlooped/oss/blob/main/.github_changelog_generator
-	sha = a9a7616a242f5ba5c910c3f1c93bb38c4b2fbd8d
-	etag = 73c55fc67df88885e402f87d24c36cd5df6a08604ae1c3256ee0413d115975c6
+	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
+	etag = f9e85892ecefdc98584d9a90c3b29e63e910f161b8761a51eaeb94dfa9bd3e4f
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = fa83a5161ba52bc5d510ce0ba75ee0b1f8d4bc63
-	etag = 925782b685859e07040442303b411bebd1c75b4fe4e075f547e067f33f323814
+	sha = a9f9d3f5db6dd0714f52da61e35ab233fd0a1642
+	etag = e6ba96dc8c185a4e9c64f7c2c8003ef86e8f73624865ff7f6ae955aad55a164e
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -114,13 +109,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = 32213f2169e34df06da3e1589e52186f2cf57baf
-	etag = afbaf6c253fd1a427ace8405cca937b62a60328c218ca794f501dc66cdf81180
+	sha = cc6922f63e2bd520a75f46592cfb38cec02aaccd
+	etag = 743fd7845e40d9aef662f858a2d48dbfec9a10977e15394f45e331841a3c0dfd
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = fde1f6f17926f429a52e64de5ec355bb643e25bc
-	etag = 126357bbdcfd2ee087986bd27f1817926f6585fba7eda4c9acb36975474fd1b7
+	sha = 83d73781f82a05b805c98b70219c32a47c096fbe
+	etag = 7b62ae495bdfb2dcca473709323ab0d5cf2bb7637e7bff3250ae9267839069ef
 	weak
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
@@ -151,4 +146,9 @@
 	url = https://github.com/devlooped/.github/blob/main/Gemfile
 	sha = f2dc1370469bec1b2d32d82faf659b050cdc7e2a
 	etag = d45832acd078778ffebf260000f6d25172a131f51684744d7e982da2a47170ce
+	weak
+[file ".github/.github_changelog_generator"]
+	url = https://github.com/devlooped/oss/blob/main/.github/.github_changelog_generator
+	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
+	etag = 28145d505ce95b57628ab368bb12744300d5f539d3651c346e3c0c3f772ffa7b
 	weak

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,7 +23,13 @@
     <Copyright>Copyright (C) Daniel Cazzulino and Contributors. All rights reserved.</Copyright>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
+    <!-- Pick src-level readme+icon automatically -->
     <PackageIcon Condition="Exists('$(MSBuildThisFileDirectory)icon.png')">icon.png</PackageIcon>
+    <PackageReadmeFile Condition="Exists('$(MSBuildThisFileDirectory)readme.md')">readme.md</PackageReadmeFile>
+    <!-- Pick project-level readme+icon overrides automatically -->
+    <PackageIcon Condition="Exists('$(MSBuildProjectDirectory)\icon.png')">icon.png</PackageIcon>
+    <PackageReadmeFile Condition="Exists('$(MSBuildProjectDirectory)\readme.md')">readme.md</PackageReadmeFile>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GenerateRepositoryUrlAttribute>true</GenerateRepositoryUrlAttribute>
@@ -32,18 +38,11 @@
 
     <!-- Use Directory.Packages.props if possible. NOTE: other MSBuild SDKs (i.e. NoTargets/Traversal) do not support central packages -->
     <ManagePackageVersionsCentrally Condition="Exists('$(MSBuildThisFileDirectory)Directory.Packages.props') AND ('$(MSBuildProjectExtension)' == '.csproj' OR '$(MSBuildProjectExtension)' == '.vbproj')">true</ManagePackageVersionsCentrally>
-    <!-- Always add our my CI package feed first for easier dogfooding -->
-    <RestoreSources>https://pkg.kzu.io/index.json;https://api.nuget.org/v3/index.json;$(RestoreSources)</RestoreSources>
-  </PropertyGroup>
+    <RestoreSources>https://api.nuget.org/v3/index.json;https://pkg.kzu.io/index.json;$(RestoreSources)</RestoreSources>
 
-  <ItemGroup Label="NuGet">
-    <!-- This is compatible with nugetizer and SDK pack -->
-    <None Include="$(MSBuildThisFileDirectory)icon.png" Link="icon.png"
-          Pack="true"
-          Visible="false"
-          PackagePath="%(Filename)%(Extension)"
-          Condition="Exists('$(MSBuildThisFileDirectory)icon.png')" />
-  </ItemGroup>
+    <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
+    <GeneratePathProperty>true</GeneratePathProperty>
+  </PropertyGroup>
 
   <PropertyGroup Label="Build">
     <Configuration Condition="'$(Configuration)' == '' and $(CI)">Release</Configuration>
@@ -84,6 +83,9 @@
     
     <!-- Preserve transitively copied content in VS: https://github.com/dotnet/msbuild/issues/1054#issuecomment-847959047 -->
     <MSBuildCopyContentTransitively>true</MSBuildCopyContentTransitively>
+    
+    <!-- Global tools should run on whatever latest runtime is installed. See https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward -->
+    <RollForward>LatestMinor</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Label="StrongName" Condition="Exists('$(MSBuildThisFileDirectory)kzu.snk')">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,8 +5,9 @@
     <DefineConstants>CI;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(IsPackable)' == '' and '$(PackAsTool)' == 'true'">
-    <IsPackable>true</IsPackable>
+  <PropertyGroup Condition="'$(IsPackable)' == ''">
+    <IsPackable Condition="'$(PackAsTool)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(PackFolder)' != ''">true</IsPackable>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(IsPackable)' == ''">
@@ -23,6 +24,28 @@
     <IsPackable Condition="'$(PackageId)' == ''">false</IsPackable>
     <IsPackable Condition="'$(PackageId)' != ''">true</IsPackable>
   </PropertyGroup>
+  
+  <ItemGroup Condition="'$(IsPackable)' == 'true'" Label="NuGet">
+    <!-- This is compatible with nugetizer and SDK pack -->
+
+    <!-- Project-level icon/readme will already be part of None items -->
+    <None Update="@(None -> WithMetadataValue('Filename', 'icon'))" 
+          Pack="true" PackagePath="%(Filename)%(Extension)" 
+          Condition="'$(PackageIcon)' != ''" />
+
+    <None Update="@(None -> WithMetadataValue('Filename', 'readme'))" 
+          Pack="true" PackagePath="%(Filename)%(Extension)" 
+          Condition="'$(PackageReadmeFile)' != ''" />
+    
+    <!-- src-level will need explicit inclusion -->
+    <None Include="$(MSBuildThisFileDirectory)icon.png" Link="icon.png" Visible="false" 
+          Pack="true" PackagePath="%(Filename)%(Extension)"
+          Condition="Exists('$(MSBuildThisFileDirectory)icon.png') and !Exists('$(MSBuildProjectDirectory)icon.png')" />
+
+    <None Include="$(MSBuildThisFileDirectory)readme.md" Link="readme.md"  
+          Pack="true" PackagePath="%(Filename)%(Extension)"
+          Condition="Exists('$(MSBuildThisFileDirectory)readme.md') and !Exists('$(MSBuildProjectDirectory)readme.md')" />
+  </ItemGroup>
 
   <!-- Microsoft.NET.Sdk\targets\Microsoft.NET.DefaultAssemblyInfo.targets does this and is imported 
        before Directory.Build.targets, but it's not imported for .msbuildproj -->
@@ -86,6 +109,7 @@
 
   <ItemGroup>
     <!-- Make these available via ThisAssembly.Project -->
+    <ProjectProperty Include="RepositoryBranch" />
     <ProjectProperty Include="RepositorySha" />
     <ProjectProperty Include="RepositoryCommit" />
   </ItemGroup>


### PR DESCRIPTION
# devlooped/oss

- Move changelog config to .github, switch to gem https://github.com/devlooped/oss/commit/b7ce2be
- Automatically retry failed tests up to 5 times https://github.com/devlooped/oss/commit/8bc16a7
- Ensure GNU grep is used on macOS https://github.com/devlooped/oss/commit/964caa3
- Add icon prefix to match dependabot https://github.com/devlooped/oss/commit/2a39a42
- Ignore TestResults folders https://github.com/devlooped/oss/commit/a9f9d3f
- Add nuget.org as first restore source, for convenience https://github.com/devlooped/oss/commit/3f294a1
- Automatically set/include icon.png and readme.md https://github.com/devlooped/oss/commit/e260665
- Global tools should run on whatever latest runtime is installed. https://github.com/devlooped/oss/commit/b65c8f1
- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] https://github.com/devlooped/oss/commit/cc6922f
- If PackFolder is specified, assume IsPackable=true https://github.com/devlooped/oss/commit/b0249cf
- Make src-level readme visible for easier editing https://github.com/devlooped/oss/commit/bfe0f2a
- Add RepositoryBranch as a ThisAssembly.Project property https://github.com/devlooped/oss/commit/83d7378