### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,7 @@ jobs:
           dotnet-version: '6.0.x'
 
       - name: ✓ ensure format
-        run: |
-          dotnet restore
-          dotnet format --verify-no-changes -v:diag
+        run: dotnet format --verify-no-changes -v:diag --exclude ~/.nuget
 
   build:
     name: build-${{ matrix.os }}
@@ -47,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-latest, macOS-latest]
+        os: [windows-latest, ubuntu-latest, macOS-latest]
     steps:
       - name: 🤘 checkout
         uses: actions/checkout@v2
@@ -57,7 +55,7 @@ jobs:
 
       - name: ⚙ dotnet
         uses: actions/setup-dotnet@v1
-        if: matrix.os != 'windows-2022'
+        if: matrix.os != 'windows-latest'
         with:
           dotnet-version: '6.0.x'
 
@@ -69,11 +67,6 @@ jobs:
         run: |
           brew install grep
           echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
-
-      - name: ⚙ azurite
-        run: |
-          npm install azurite
-          npx azurite-table &
 
       - name: 🧪 test
         uses: ./.github/workflows/test

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -28,7 +28,7 @@ runs:
                 exit 0
             fi
             # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
-            filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+            filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)[^\s]*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
             ((counter++))
         done
         exit $exitcode

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ TestResults
 *.binlog
 *.zip
 __azurite*.*
+__*__
 
 .nuget
 *.lock.json

--- a/.netconfig
+++ b/.netconfig
@@ -49,8 +49,8 @@
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = 7ebebbdbab67d9d895a29b3d2b3f82a62a7d8c4e
-	etag = 22c14ba80c39988ffd19c9b8737f541774cb75994004d432225ba4ff007f1403
+	sha = bbf637b2a565073a89783c9eb4ebd9c460823fe4
+	etag = 6b9139f22428851c8d7329973f3d92802d25e70a5e0c1b24604c23db991ac8e2
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
@@ -74,8 +74,8 @@
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = 829faad5e117383ed8eefad0e220530144ab4468
-	etag = 739f9cda1b43417a96b61941344e672098a853d6b365d8e96e351484288a78a0
+	sha = 978c71c6afd095eaba35097fd7deed44fa09aa91
+	etag = 2b49512f81b6cb44c4ee398975c0edf41bfa4137857b59770805fa7c5e49e94b
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -109,13 +109,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = cc6922f63e2bd520a75f46592cfb38cec02aaccd
-	etag = 743fd7845e40d9aef662f858a2d48dbfec9a10977e15394f45e331841a3c0dfd
+	sha = 2fea462dc563923800a7efad24a52aa0541a8864
+	etag = 819e24ed16c1257f3c6ea3c728e1507020bacf32aeb63f5dd56f9a5cb2652275
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 83d73781f82a05b805c98b70219c32a47c096fbe
-	etag = 7b62ae495bdfb2dcca473709323ab0d5cf2bb7637e7bff3250ae9267839069ef
+	sha = 024f73321ffe4e927151ff94666c52c2d425139a
+	etag = 816dff7cb821a885da46ad200f9b8bea3438d74da3172bc43716d5670abaee6c
 	weak
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
@@ -154,8 +154,8 @@
 	weak
 [file ".github/workflows/test/action.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/test/action.yml
-	sha = 3b9f317fc4f3edb926b26c4e4db9773a5f95ebca
-	etag = cf89aeff5c66fd3c0d0aaa655b527d66f5e823413c7a6788a62542e93d344576
+	sha = 2c82d7d80183eb619d48cddada414ff3c471303a
+	etag = 93a510692a6f4b5350ba486d1e944ea444612f137730f649ae6a2f96d7d970d0
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -130,6 +130,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">
+    <ProjectProperty Include="CI" />
+  
     <ProjectProperty Include="Version" />
     <ProjectProperty Include="VersionPrefix" />
     <ProjectProperty Include="VersionSuffix" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -112,6 +112,8 @@
     <ProjectProperty Include="RepositoryBranch" />
     <ProjectProperty Include="RepositorySha" />
     <ProjectProperty Include="RepositoryCommit" />
+    <ProjectProperty Include="RepositoryRoot" />
+    <ProjectProperty Include="RepositoryUrl" />
   </ItemGroup>
 
   <!-- Make sure the source control info is available before calling source generators -->
@@ -130,6 +132,15 @@
       <RepositorySha Condition="'$(RepositorySha)' == ''">$(SourceRevisionId.Substring(0, 9))</RepositorySha>
       <!-- This allows the commit label added to the InformationalVersion to be the short sha instead :) -->
       <SourceRevisionId>$(RepositorySha)</SourceRevisionId>
+    </PropertyGroup>
+
+    <!-- Add SourceRoot as a project property too -->
+    <ItemGroup>
+      <_GitSourceRoot Include="@(SourceRoot -> WithMetadataValue('SourceControl', 'git'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <RepositoryRoot>@(_GitSourceRoot)</RepositoryRoot>
     </PropertyGroup>
 
   </Target>
@@ -153,55 +164,5 @@ Built from $(RepositoryUrl)/tree/$(RepositorySha)
 
   <!-- Import before UsingTask because first to declare tasks wins -->
   <Import Project="Directory.targets" Condition="Exists('Directory.targets')"/>
-
-  <!--
-  ==============================================================
-    DumpItems Task
-    Helper task useful for quickly inspecting the full metadata
-    of arbitrary items in any target.
-
-    Properties:
-    - Items: Microsoft.Build.Framework.ITaskItem[] (Input, Required)
-    - ItemName: string (Input, Optional)
-	==============================================================
-  -->
-  <UsingTask TaskName="DumpItems" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <Items ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-      <ItemName />
-    </ParameterGroup>
-    <Task>
-      <Reference Include="Microsoft.Build" />
-      <Reference Include="Microsoft.CSharp" />
-      <Reference Include="System" />
-      <Reference Include="System.Core" />
-      <Using Namespace="Microsoft.Build.Framework" />
-      <Using Namespace="Microsoft.Build.Utilities" />
-      <Using Namespace="System" />
-      <Using Namespace="System.Linq" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-			  var itemName = ItemName ?? "Item";
-			  if (Items.Length == 0)
-				  Log.LogMessage(MessageImportance.High, "No {0} items received to dump.", ItemName ?? "");
-			  else
-				  Log.LogMessage(MessageImportance.High, "Dumping {0} {1} items.", Items.Length, ItemName ?? "");
-
-			  foreach (var item in Items.OrderBy(i => i.ItemSpec))
-			  {
-				  Log.LogMessage(MessageImportance.High, "{0}: {1}", itemName, item.ItemSpec);
-				  foreach (var name in item.MetadataNames.OfType<string>().OrderBy(_ => _))
-				  {
-					  try
-					  {
-						  Log.LogMessage(MessageImportance.High, "\t{0}={1}", name, item.GetMetadata(name));
-					  }
-					  catch { }
-				  }
-			  }
-      ]]>
-      </Code>
-    </Task>
-  </UsingTask>
 
 </Project>


### PR DESCRIPTION
# devlooped/oss

- Switch to windows-latest agent which is now .NET6 https://github.com/devlooped/oss/commit/445239b
- Ignore nuget-provided files for formatting https://github.com/devlooped/oss/commit/bbf637b
- Add RepositoryRoot property from source control information https://github.com/devlooped/oss/commit/f9763d3
- Add RepositoryUrl as project property, if available https://github.com/devlooped/oss/commit/4f57ffe
- Add azurite hidden folders too https://github.com/devlooped/oss/commit/978c71c
- Remove DumpItems task. Easily replaceable with MSBuild.DumpItems https://github.com/devlooped/oss/commit/024f733
- Fix matching of failed test names https://github.com/devlooped/oss/commit/2c82d7d
- Add CI as a project property https://github.com/devlooped/oss/commit/2fea462