### PR TITLE
Fix test filter for theory tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,12 @@ jobs:
           brew install grep
           echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
 
+      - name: ⚙ azurite
+        run: |
+          npm install azurite
+          npx azurite --version
+          npx azurite &
+
       - name: 🧪 test
         uses: ./.github/workflows/test
 

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -27,8 +27,8 @@ runs:
             then
                 exit 0
             fi
-            # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
-            filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)[^\s]*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
+            # cat output, get failed test names, remove trailing whitespace, sort+dedupe, join as FQN~TEST with |, remove trailing |.
+            filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)[\w\._]*' | sed 's/ *$//g' | sort -u | awk 'BEGIN { ORS="|" } { print("FullyQualifiedName~" $0) }' | grep -o -P '.*(?=\|$)')
             ((counter++))
         done
         exit $exitcode

--- a/.netconfig
+++ b/.netconfig
@@ -154,8 +154,8 @@
 	weak
 [file ".github/workflows/test/action.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/test/action.yml
-	sha = 2c82d7d80183eb619d48cddada414ff3c471303a
-	etag = 93a510692a6f4b5350ba486d1e944ea444612f137730f649ae6a2f96d7d970d0
+	sha = fca55bc0e439be202a4480a682415a92c09b7672
+	etag = e75412a4af8b83897504e754f9a95cd4ebcd95b358857047afeb3cd97b2497ba
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config

--- a/src/TableStorage/TableRepository`1.cs
+++ b/src/TableStorage/TableRepository`1.cs
@@ -193,13 +193,13 @@ namespace Devlooped
             // perform its advanced ctor and conversion detection as usual.
             writer.WriteStartObject();
 
-            if (partitionKeyProperty != null)
+            if (partitionKeyProperty != null && !entity.ContainsKey(partitionKeyProperty))
                 writer.WriteString(partitionKeyProperty, entity.PartitionKey);
 
-            if (rowKeyProperty != null)
+            if (rowKeyProperty != null && !entity.ContainsKey(rowKeyProperty))
                 writer.WriteString(rowKeyProperty, entity.RowKey);
 
-            if (entity.Timestamp != null)
+            if (entity.Timestamp != null && !entity.ContainsKey(nameof(ITableEntity.Timestamp)))
                 writer.WriteString(nameof(ITableEntity.Timestamp), entity.Timestamp.Value.ToString("O"));
 
             foreach (var property in entity)

--- a/src/Tests/.editorconfig
+++ b/src/Tests/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# xUnit1013: Public method should be marked as test
+dotnet_diagnostic.xUnit1013.severity = none

--- a/src/Tests/QueryTests.cs
+++ b/src/Tests/QueryTests.cs
@@ -44,7 +44,14 @@ namespace Devlooped
         public async Task CanProject()
         {
             var account = CloudStorageAccount.DevelopmentStorageAccount;
-            var repo = TableRepository.Create<Book>(account, nameof(CanProject), x => x.Author, x => x.ISBN);
+            var repo = TableRepository.Create<Book>(account, $"{nameof(QueryTests)}{nameof(CanProject)}", x => x.Author, x => x.ISBN);
+
+            // For some reason, this test alone fails due to what looks like a timing issue in finishing creating the table
+            while ((await account.CreateTableServiceClient().GetTableClient(repo.TableName).CreateIfNotExistsAsync()) != null)
+            {
+                await Task.Delay(50);
+            }
+
             await LoadBooksAsync(repo);
 
             var hasResults = false;

--- a/src/Tests/RepositoryTests.cs
+++ b/src/Tests/RepositoryTests.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Data.Tables;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Devlooped
 {
-    public class RepositoryTests
+    public record RepositoryTests(ITestOutputHelper Output)
     {
         [Fact]
         public async Task TableEndToEnd()
@@ -46,6 +48,8 @@ namespace Devlooped
         public async Task TableRecordEndToEnd()
         {
             var repo = TableRepository.Create<AttributedRecordEntity>(CloudStorageAccount.DevelopmentStorageAccount);
+            Output.WriteLine("Target table: " + repo.TableName);
+
             var entity = await repo.PutAsync(new AttributedRecordEntity("Book", "1234"));
 
             Assert.Equal("1234", entity.ID);
@@ -427,7 +431,7 @@ namespace Devlooped
             public string? Status { get; set; }
         }
 
-        [Table("Record")]
+        [Table("EntityRequest")]
         record AttributedRecordEntity([PartitionKey] string Kind, [RowKey] string ID)
         {
             public string? Status { get; set; }


### PR DESCRIPTION
Theories contain additional characters in the test display name,
including whitespaces and a rendering of the data elements for each
test, such as `Devlooped.DocumentRepositoryTests.DocumentEndToEnd(serializer: DocumentSerializer { })`.

The existing regex would truncate the string at the whitespace,
resulting in `Devlooped.DocumentRepositoryTests.DocumentEndToEnd(serializer:`
which then wouldn't match any tests, making it appear that the test
run was otherwise successful.

This fixes that by switching to test full name. Also adds workarounds for 
a few remaining test failures on CI.