### PR TITLE
Reduce scope of key property lookup to direct property lambda

### DIFF
--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -15,12 +15,14 @@ runs:
         warn="\e[0;33m"
         while [ $counter -lt 6 ]
         do
+            # run test and forward output also to a file in addition to stdout (tee command)
             if [ $filter ]
             then
                 echo -e "${warn}Retry $counter for $filter ${reset}"
+                dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
+            else
+                dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m | tee ./output.log
             fi
-            # run test and forward output also to a file in addition to stdout (tee command)
-            dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
             # capture dotnet test exit status, different from tee
             exitcode=${PIPESTATUS[0]}
             if [ $exitcode == 0 ]

--- a/src/TableStorage/ExpressionExtensions.cs
+++ b/src/TableStorage/ExpressionExtensions.cs
@@ -17,23 +17,8 @@ namespace Devlooped
                 member.Member is PropertyInfo property)
                 return property.Name;
 
-            var visitor = new FindPropertyVisitor();
-            visitor.Visit(expression);
-
-            return visitor.Property?.Name;
-        }
-
-        class FindPropertyVisitor : ExpressionVisitor
-        {
-            public PropertyInfo? Property { get; set; }
-
-            protected override Expression VisitMember(MemberExpression node)
-            {
-                if (node.Member is PropertyInfo property)
-                    Property = property;
-
-                return base.VisitMember(node);
-            }
+            // We do not support anything except a straight property getter expression.
+            return null;
         }
     }
 }


### PR DESCRIPTION
Otherwise, we can end up breaking up serialization.

Fixes #100