### PR TITLE
Allow creating partitions from the same table connection

### DIFF
--- a/src/TableStorage/DocumentSerializer.cs
+++ b/src/TableStorage/DocumentSerializer.cs
@@ -9,7 +9,7 @@ namespace Devlooped
 {
     /// <summary>
     /// Default implementation of <see cref="IStringDocumentSerializer"/> which 
-    /// uses Newtonsoft.Json for serialization.
+    /// uses System.Text.Json for serialization.
     /// </summary>
     partial class DocumentSerializer : IStringDocumentSerializer
     {

--- a/src/TableStorage/TableConnection.cs
+++ b/src/TableStorage/TableConnection.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading.Tasks;
+using Azure.Data.Tables;
+
+namespace Devlooped
+{
+    /// <summary>
+    /// Represents a connection to a given <see cref="TableName"/> 
+    /// over a given <see cref="CloudStorageAccount"/>.
+    /// </summary>
+    partial class TableConnection
+    {
+        readonly CloudStorageAccount storageAccount;
+        TableClient? table;
+
+        /// <summary>
+        /// Creates the affinitized table connection for the given table name.
+        /// </summary>
+        /// <param name="storageAccount">The storage account to use.</param>
+        /// <param name="tableName">The table to connect to.</param>
+        public TableConnection(CloudStorageAccount storageAccount, string tableName)
+        {
+            this.storageAccount = storageAccount;
+            TableName = tableName;
+        }
+
+        /// <summary>
+        /// Gets the storage account used to connect to the table.
+        /// </summary>
+        public CloudStorageAccount StorageAccount => storageAccount;
+
+        /// <summary>
+        /// Gets the name of the table to use.
+        /// </summary>
+        public string TableName { get; }
+
+        /// <summary>
+        /// Gets table client, creating the table if it doesn't exist.
+        /// </summary>
+        internal async Task<TableClient> GetTableAsync() => table ??= await CreateTableClientAsync();
+
+        async Task<TableClient> CreateTableClientAsync()
+        {
+            var tableClient = storageAccount.CreateTableServiceClient();
+            var table = tableClient.GetTableClient(TableName);
+            await table.CreateIfNotExistsAsync();
+            return table;
+        }
+    }
+}

--- a/src/TableStorage/TableEntityPartition.cs
+++ b/src/TableStorage/TableEntityPartition.cs
@@ -22,14 +22,23 @@ namespace Devlooped
         /// <param name="tableName">The table that backs this table partition.</param>
         /// <param name="partitionKey">The fixed partition key that backs this table partition.</param>
         protected internal TableEntityPartition(CloudStorageAccount storageAccount, string tableName, string partitionKey)
+            : this(new TableConnection(storageAccount, tableName), partitionKey)
         {
-            TableName = tableName;
+        }
+
+        /// <summary>
+        /// Initializes the repository with the given storage account and optional table name.
+        /// </summary>
+        /// <param name="tableConnection">The <see cref="TableConnection"/> to use to connect to the table.</param>
+        /// <param name="partitionKey">The fixed partition key that backs this table partition.</param>
+        protected internal TableEntityPartition(TableConnection tableConnection, string partitionKey)
+        {
             PartitionKey = partitionKey;
-            repository = new TableEntityRepository(storageAccount, TableName);
+            repository = new TableEntityRepository(tableConnection);
         }
 
         /// <inheritdoc />
-        public string TableName { get; }
+        public string TableName => repository.TableName;
 
         /// <inheritdoc />
         public string PartitionKey { get; }

--- a/src/TableStorage/TablePartition`1.cs
+++ b/src/TableStorage/TablePartition`1.cs
@@ -24,19 +24,27 @@ namespace Devlooped
         /// <param name="partitionKey">The fixed partition key that backs this table partition.</param>
         /// <param name="rowKey">A function to determine the row key for an entity of type <typeparamref name="T"/> within the partition.</param>
         protected internal TablePartition(CloudStorageAccount storageAccount, string tableName, string partitionKey, Expression<Func<T, string>> rowKey)
+            : this(new TableConnection(storageAccount, tableName ?? TablePartition.GetDefaultTableName<T>()), partitionKey, rowKey)
         {
-            TableName = tableName ?? TablePartition.GetDefaultTableName<T>();
+        }
+
+        /// <summary>
+        /// Initializes the repository with the given storage account and optional table name.
+        /// </summary>
+        /// <param name="tableStorage">The storage account and table to use.</param>
+        /// <param name="partitionKey">The fixed partition key that backs this table partition.</param>
+        /// <param name="rowKey">A function to determine the row key for an entity of type <typeparamref name="T"/> within the partition.</param>
+        protected internal TablePartition(TableConnection tableStorage, string partitionKey, Expression<Func<T, string>> rowKey)
+        {
             partitionKey ??= TablePartition.GetDefaultPartitionKey<T>();
             PartitionKey = partitionKey;
 
-            repository = new TableRepository<T>(storageAccount,
-                TableName,
-                _ => partitionKey,
+            repository = new TableRepository<T>(tableStorage, _ => partitionKey,
                 rowKey ?? RowKeyAttribute.CreateAccessor<T>());
         }
 
         /// <inheritdoc />
-        public string TableName { get; }
+        public string TableName => repository.TableName;
 
         /// <inheritdoc />
         public string PartitionKey { get; }

--- a/src/TableStorage/Visibility.cs
+++ b/src/TableStorage/Visibility.cs
@@ -14,6 +14,7 @@ public partial interface IBinaryDocumentSerializer { }
 public partial interface IStringDocumentSerializer { }
 public partial interface IDocumentEntity { }
 
+public partial class TableConnection { }
 public partial class TableRepository { }
 public partial class TableRepository<T> { }
 public partial class AttributedTableRepository<T> { }


### PR DESCRIPTION
By exposing the explicit concept of an affinitized table-based storage account+table name, we make it possible to avoid checking for table existence on every new instance of a table repository or partition.

We now also don't fire up a task to check for the table existence, which also minimizes chances of an unhandled background exception.

Closes #155