### PR TITLE
As documented [PartitionKey], honor it at class level

### DIFF
--- a/src/TableStorage/TablePartition.cs
+++ b/src/TableStorage/TablePartition.cs
@@ -2,6 +2,7 @@
 #nullable enable
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Azure.Data.Tables;
@@ -145,8 +146,10 @@ namespace Devlooped
         /// Gets a default partition key to use for entities of type <typeparamref name="T"/>. Will be the 
         /// the type name, stripped of a suffix <c>Entity</c> if present.
         /// </summary>
-        public static string GetDefaultPartitionKey<T>() => typeof(T).Name.EndsWith("Entity") ?
+        public static string GetDefaultPartitionKey<T>() => 
+            typeof(T).GetCustomAttribute<PartitionKeyAttribute>()?.PartitionKey ??
+            (typeof(T).Name.EndsWith("Entity") ?
             typeof(T).Name.Substring(0, typeof(T).Name.Length - 6) :
-            typeof(T).Name;
+            typeof(T).Name);
     }
 }

--- a/src/Tests/RepositoryTests.cs
+++ b/src/Tests/RepositoryTests.cs
@@ -430,6 +430,17 @@ namespace Devlooped
             Assert.Equal("rocks", entity["Notes"]);
         }
 
+        [Fact]
+        public void CanAnnotateFixedPartition()
+        {
+            var partition = TablePartition.Create<CustomPartition>(
+                CloudStorageAccount.DevelopmentStorageAccount,
+                nameof(CanAnnotateFixedPartition),
+                x => x.Id);
+
+            Assert.Equal("MyPartition", partition.PartitionKey);
+        }
+
         class MyEntity
         {
             public MyEntity(string id) => Id = id;
@@ -484,5 +495,8 @@ namespace Devlooped
         {
             public DateTime? Timestamp { get; set; }
         }
+
+        [PartitionKey("MyPartition")]
+        record CustomPartition(string Id);
     }
 }


### PR DESCRIPTION
Its value should be used by default if present, instead of the type name.