### PR TITLE
Update mode on table partition should set table repository mode

### DIFF
--- a/src/TableStorage/TablePartition`1.cs
+++ b/src/TableStorage/TablePartition`1.cs
@@ -52,7 +52,11 @@ namespace Devlooped
         /// <summary>
         /// The <see cref="TableUpdateMode"/> to use when updating an existing entity.
         /// </summary>
-        public TableUpdateMode UpdateMode { get; set; }
+        public TableUpdateMode UpdateMode 
+        {
+            get => repository.UpdateMode;
+            set => repository.UpdateMode = value; 
+        }
 
         /// <summary>
         /// The strategy to use when updating an existing entity.
@@ -61,8 +65,8 @@ namespace Devlooped
         public UpdateStrategy UpdateStrategy
         {
             // Backs-compatible implementation
-            get => UpdateMode == TableUpdateMode.Replace ? UpdateStrategy.Replace : UpdateStrategy.Merge;
-            set => UpdateMode = value.UpdateMode;
+            get => repository.UpdateStrategy;
+            set => repository.UpdateStrategy = value;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
By not setting the value in the underlying table, when setting the value via a property setter, we ended up not honoring it at all.