### PR TITLE
Improve persistence by annotating supported types with OData Edm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,8 @@ your "real" data, but for reference data, it could come in handy.
 Stored entities using `TableRepository` and `TablePartition` use individual columns for 
 properties, which makes it easy to browse the data (and query, as shown above!). 
 
+> NOTE: partition and row keys can also be typed as `Guid`
+
 But document-based storage is also available via `DocumentRepository` and `DocumentPartition` if 
 you don't need the individual columns.
 

--- a/src/TableStorage/DocumentRepository`1.cs
+++ b/src/TableStorage/DocumentRepository`1.cs
@@ -180,6 +180,7 @@ namespace Devlooped
 
             var row = ToTable(entity);
             row["Document"] = binarySerializer!.Serialize(entity);
+            row["Document@odata.type"] = "Edm.Binary";
 
             // We use Replace because all the existing entity data is in a single 
             // column, no point in merging since it can't be done at that level anyway.
@@ -266,7 +267,7 @@ namespace Devlooped
 
             foreach (var prop in EntityPropertiesMapper.Default.ToProperties(entity))
             {
-                // Never allow properties to overwrite out built-in queryable columns
+                // Never allow properties to overwrite our built-in queryable columns
                 if (!te.ContainsKey(prop.Key))
                     te[prop.Key] = prop.Value;
             }

--- a/src/TableStorage/TableEntityPartition.cs
+++ b/src/TableStorage/TableEntityPartition.cs
@@ -10,7 +10,10 @@ using Azure.Data.Tables;
 
 namespace Devlooped
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// A specific partition within a <see cref="TableEntityRepository"/>, which 
+    /// allows querying by the entity properties, since they are stored in individual columns.
+    /// </summary>
     partial class TableEntityPartition : ITablePartition<TableEntity>
     {
         readonly TableEntityRepository repository;

--- a/src/TableStorage/TableEntityRepository.cs
+++ b/src/TableStorage/TableEntityRepository.cs
@@ -12,7 +12,10 @@ using Azure.Data.Tables;
 
 namespace Devlooped
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Default implementation of <see cref="ITableRepository{TableEntity}"/> which allows querying 
+    /// the repository by the entity properties, since they are stored in individual columns.
+    /// </summary>
     partial class TableEntityRepository : ITableRepository<TableEntity>
     {
         TableConnection tableConnection;

--- a/src/TableStorage/TableRepositoryQuery`1.cs
+++ b/src/TableStorage/TableRepositoryQuery`1.cs
@@ -254,7 +254,8 @@ namespace Devlooped
                                     dictionary.Add(property.Name, Convert.FromBase64String(value));
                                     continue;
                                 case "Edm.DateTime":
-                                    dictionary.Add(property.Name, DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
+                                    // Reading from Azure SDK will always return DateTimeOffset for dates, instead of date time.
+                                    dictionary.Add(property.Name, DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
                                     continue;
                                 case "Edm.Guid":
                                     dictionary.Add(property.Name, Guid.Parse(value));

--- a/src/TableStorage/TableStorageAttribute.cs
+++ b/src/TableStorage/TableStorageAttribute.cs
@@ -77,8 +77,8 @@ namespace Devlooped
                 throw new ArgumentException($"Expected entity type '{typeof(TEntity).Name}' to have one property annotated with [{attributeName}]");
             }
 
-            if (keyProp.PropertyType != typeof(string))
-                throw new ArgumentException($"Property '{typeof(TEntity).Name}.{keyProp.Name}' annotated with [{attributeName}] must be of type string.");
+            if (keyProp.PropertyType != typeof(string) && keyProp.PropertyType != typeof(Guid))
+                throw new ArgumentException($"Property '{typeof(TEntity).Name}.{keyProp.Name}' annotated with [{attributeName}] must be of type string or Guid.");
 
             var param = Expression.Parameter(typeof(TEntity), "entity");
 
@@ -94,7 +94,9 @@ namespace Devlooped
                         typeof(TableStorageAttribute).GetMethod(nameof(EnsureValid), BindingFlags.NonPublic | BindingFlags.Static)!,
                         Expression.Constant(attributeName),
                         Expression.Constant(keyProp.Name, typeof(string)),
-                        Expression.Property(param, keyProp))),
+                        keyProp.PropertyType == typeof(string)
+                            ? Expression.Property(param, keyProp)
+                            : Expression.Call(Expression.Property(param, keyProp), typeof(Guid).GetMethod(nameof(Guid.ToString), Type.EmptyTypes)!))),
                 param);
         }
 

--- a/src/Tests/DocumentRepositoryTests.cs
+++ b/src/Tests/DocumentRepositoryTests.cs
@@ -62,6 +62,15 @@ namespace Devlooped
 
                 Assert.Single(entities);
 
+                // Verify that the entity is not serialized as a string for non-string serializer
+                if (serializer is not IStringDocumentSerializer)
+                {
+                    var generic = TableRepository.Create(CloudStorageAccount.DevelopmentStorageAccount, table.Name);
+                    var row = await generic.GetAsync(partitionKey, rowKey);
+                    Assert.NotNull(row);
+                    Assert.IsType<byte[]>(row["Document"]);
+                }
+
                 await repo.DeleteAsync(saved);
 
                 Assert.Null(await repo.GetAsync(partitionKey, rowKey));


### PR DESCRIPTION
Previously, we didn't ever annotate properties with OData Edm types, meaning the following supported native column types in Azure Tables would all be converted (and used) as plain strings: byte[], DateTimeOffset, Guid and long.

By following more closely the documentation at https://learn.microsoft.com/en-us/rest/api/storageservices/payload-format-for-table-service-operations#property-types-in-a-json-feed, we effectively make our API more optimal and compatible with the Azure SDK for Table Storage.

In order to avoid too many breaking changes, we only support Edm.DateTime annotation for DateTimeOffset properties, since that's the behavior of the SDK when deserializing such annotated values (not to DateTime). This effectively means that DateTime is more of a legacy type that might best be avoided.

This also now allows using a GUID-typed property for both partition and row keys.

Closes #235.