### PR TITLE
Empty query results does not throw

### DIFF
--- a/src/TableStorage/TableRepositoryQuery`1.cs
+++ b/src/TableStorage/TableRepositoryQuery`1.cs
@@ -129,6 +129,9 @@ namespace Devlooped
             var response = await Http.Client.SendAsync(request);
             while (true)
             {
+                if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                    yield break;
+
                 response.EnsureSuccessStatusCode();
 
                 var json = await response.Content.ReadAsStringAsync();

--- a/src/Tests/QueryTests.cs
+++ b/src/Tests/QueryTests.cs
@@ -220,6 +220,21 @@ namespace Devlooped
             }
         }
 
+        [Fact]
+        public async Task EmptyQueryDoesNotFail()
+        {
+            var account = CloudStorageAccount.DevelopmentStorageAccount;
+            var repo = TableRepository.Create(account, TableName());
+
+            var query = from book in repo.CreateQuery()
+                        where
+                            book.PartitionKey == "Rick Riordan" &&
+                            book.RowKey.CompareTo("97814231") >= 0 &&
+                            book.RowKey.CompareTo("97814232") < 0
+                        select book;
+
+            Assert.Empty((await query.AsAsyncEnumerable().ToListAsync()));
+        }
 
         async Task LoadBooksAsync(ITableStorage<Book> books)
         {


### PR DESCRIPTION
We now check for 404 since that's the expected response, which we can consider as an empty result set.