### PR TITLE
Properly persist computed colums for same type

### DIFF
--- a/src/TableStorage/EntityPropertiesMapper.cs
+++ b/src/TableStorage/EntityPropertiesMapper.cs
@@ -12,7 +12,7 @@ namespace Devlooped
 {
     class EntityPropertiesMapper
     {
-        static readonly ConcurrentDictionary<Type, PropertyInfo[]> propertiesMap = new();
+        static readonly ConcurrentDictionary<(Type, string), PropertyInfo[]> propertiesMap = new();
         static readonly ConcurrentDictionary<Type, IDictionary<string, string>> edmAnnotations = new();
         static readonly KeyValuePair<string, string> edmNone = new("", "");
 
@@ -22,7 +22,7 @@ namespace Devlooped
 
         public IDictionary<string, object> ToProperties<T>(T entity, string? partitionKeyProperty = default, string? rowKeyProperty = default) where T: notnull
         {
-            var properties = propertiesMap.GetOrAdd(entity.GetType(), type => type
+            var properties = propertiesMap.GetOrAdd((entity.GetType(), $"{partitionKeyProperty}|{rowKeyProperty}"), key => key.Item1
                 .GetProperties()
                 .Where(prop =>
                     prop.GetCustomAttribute<BrowsableAttribute>()?.Browsable != false &&


### PR DESCRIPTION
We had a bug where we cached the list of properties to persist by type, without regard for the variability in PK/RK names which can be different when persisting the same entity using various key strategies for indexing purposes.

By considering these two properties as part of the cache key, we allow proper persistence as originally intended to avoid duplicating PK/RK props.

Fixes #252