### PR TITLE
Fix TableEntity deserialization issue with newer Azurite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: ⚙ azurite
         run: |
-          npm install azurite@3.20.1
+          npm install azurite
           npx azurite &
 
       - name: 🧪 test

--- a/src/TableStorage/TableRepositoryQuery`1.cs
+++ b/src/TableStorage/TableRepositoryQuery`1.cs
@@ -267,6 +267,12 @@ namespace Devlooped
                                     dictionary.Add(property.Name, long.Parse(value, CultureInfo.InvariantCulture));
                                     continue;
                             }
+                        } 
+                        else if (property.Name == nameof(ITableEntity.Timestamp))
+                        {
+                            // Reading from Azure SDK will always return DateTimeOffset for dates, instead of date time.
+                            dictionary.Add(property.Name, DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
+                            continue;
                         }
 
                         dictionary.Add(property.Name, value);
@@ -316,9 +322,10 @@ namespace Devlooped
                 {
                     if (node.Method.Name == "get_Item" && node.Method.GetParameters() is var parameters &&
                         parameters.Length == 1 &&
-                        node.Arguments[0] is ConstantExpression constant)
+                        node.Arguments[0] is ConstantExpression constant && 
+                        constant.Value is string value)
                     {
-                        Properties.Add((string)constant.Value);
+                        Properties.Add(value);
                     }
 
                     return node;

--- a/src/Tests/QueryTests.cs
+++ b/src/Tests/QueryTests.cs
@@ -174,6 +174,26 @@ namespace Devlooped
         }
 
         [Fact]
+        public async Task CanQueryWithAndWithoutFilter()
+        {
+            var repo = TableRepository.Create(CloudStorageAccount.DevelopmentStorageAccount, "test2");
+            await repo.PutAsync(new TableEntity("partition", "row")
+            {
+                { "foo", "bar" }
+            });
+
+            await foreach (var item in repo.CreateQuery().Where(x => x.PartitionKey == "foo"))
+            {
+                Assert.NotNull(item.Timestamp);
+            }
+
+            await foreach (var item in repo.CreateQuery())
+            {
+                Assert.NotNull(item.Timestamp);
+            }
+        }
+
+        [Fact]
         public async Task CanFilterByEntityRowKey()
         {
             var account = CloudStorageAccount.DevelopmentStorageAccount;
@@ -194,7 +214,7 @@ namespace Devlooped
             Assert.NotEmpty(entity.PartitionKey);
             Assert.NotEmpty(entity.RowKey);
             Assert.NotEqual(default(ETag), entity.ETag);
-            Assert.NotEqual(DateTime.MinValue, entity.Timestamp);
+            Assert.NotNull(entity.Timestamp);
 
             var projection = from book in repo.CreateQuery()
                              where


### PR DESCRIPTION
We were requesting minimal metadata, and it seems they are not returning that for Timestamp anymore since v3.20.1 where this worked as-is.

Added a condition to always parse as datetime for that particular property even if we don't get any metadata.