### PR TITLE
Make default DocumentSerializer public

### DIFF
--- a/src/TableStorage/Visibility.cs
+++ b/src/TableStorage/Visibility.cs
@@ -20,6 +20,7 @@ public partial class TableRepository<T> { }
 public partial class AttributedTableRepository<T> { }
 public partial class DocumentRepository { }
 public partial class DocumentRepository<T> { }
+public partial class DocumentSerializer { }
 public partial class AttributedDocumentRepository<T> { }
 public partial class TablePartition { }
 public partial class TablePartition<T> { }


### PR DESCRIPTION
This is useful for customizing the serialization options when using the default document serializer with minimal tweaks.