### PR TITLE
Fix document partition query bug with entity properties

### DIFF
--- a/src/TableStorage.Source/TableStorage.Source.csproj
+++ b/src/TableStorage.Source/TableStorage.Source.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.OData.Client" Version="7.17.0" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="6.0.10" />
+    <PackageReference Include="Mono.Linq.Expressions" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TableStorage/DocumentPartition`1.cs
+++ b/src/TableStorage/DocumentPartition`1.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Mono.Linq.Expressions;
 
 namespace Devlooped
 {
@@ -66,7 +67,7 @@ namespace Devlooped
 
         /// <inheritdoc />
         public IAsyncEnumerable<T> EnumerateAsync(Expression<Func<IDocumentEntity, bool>> predicate, CancellationToken cancellation = default)
-            => repository.EnumerateAsync(e => e.PartitionKey == PartitionKey, cancellation);
+            => repository.EnumerateAsync(predicate.AndAlso(x => x.PartitionKey == PartitionKey), cancellation);
 
         /// <inheritdoc />
         public Task<T?> GetAsync(string rowKey, CancellationToken cancellation = default)

--- a/src/TableStorage/DocumentRepository`1.cs
+++ b/src/TableStorage/DocumentRepository`1.cs
@@ -15,6 +15,7 @@ namespace Devlooped
     /// <inheritdoc />
     partial class DocumentRepository<T> : IDocumentRepository<T> where T : class
     {
+        static readonly string documentType = typeof(T).FullName?.Replace('+', '.') ?? typeof(T).Name;
         static readonly string documentVersion;
         static readonly int documentMajorVersion;
         static readonly int documentMinorVersion;
@@ -325,7 +326,7 @@ namespace Devlooped
         {
             var te = new TableEntity(this.partitionKey.Invoke(entity), this.rowKey.Invoke(entity))
             {
-                { "Type", typeof(T).FullName?.Replace('+', '.') },
+                { "Type", documentType },
                 { "Version", documentVersion },
                 { "MajorVersion", documentMajorVersion },
                 { "MinorVersion", documentMinorVersion },

--- a/src/TableStorage/TableStorage.csproj
+++ b/src/TableStorage/TableStorage.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.OData.Client" Version="7.21.3" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="6.0.10" />
+    <PackageReference Include="Mono.Linq.Expressions" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Tests/DocumentRepositoryTests.cs
+++ b/src/Tests/DocumentRepositoryTests.cs
@@ -277,6 +277,31 @@ namespace Devlooped
                     .DeleteAsync("foo"));
         }
 
+        [Fact]
+        public async Task CanQueryPartitionByExpression()
+        {
+            var partition = CreatePartition(DocumentSerializer.Default);
+            var partitionKey = TablePartition.GetDefaultPartitionKey<DocumentEntity>();
+
+            await partition.PutAsync(new DocumentEntity
+            {
+                PartitionKey = partitionKey,
+                RowKey = "Foo",
+                Title = "Foo",
+            });
+
+            await partition.PutAsync(new DocumentEntity
+            {
+                PartitionKey = partitionKey,
+                RowKey = "Bar",
+                Title = "Bar",
+            });
+
+            var entity = await partition.EnumerateAsync(x => x.RowKey == "Bar").ToListAsync();
+
+            Assert.Single(entity);
+        }
+
         [ProtoContract]
         [MessagePackObject]
         public class DocumentEntity : IDocumentTimestamp


### PR DESCRIPTION
We were basically ignoring the predicate expression and replacing it with the partition key filter expression only, meaning we would never apply the actual filter the user provided.

This uses expression combining now like the memory implementation does.